### PR TITLE
expand developer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,20 @@ A digital textbook for working with huge 3D imaging datasets
 
 ## Contributing
 
-This book is built using [Jupyter Book](https://jupyterbook.org/en/stable/intro.html).
+This book is built using [Jupyter Book](https://next.jupyterbook.org/).
 To build the book locally run:
 
 ```bash
+cd book
 jupyter book start --execute
 ```
 
+This command will print a link that can be opened in a web browser to preview the book locally.
+
 To develop the book, it's recommended to use `uv`.
 Run `uv run jupyter lab` to start Jupyter, and then navigate to the `book` directory.
-Then right-click on one of the chapters and select "Open With" > "Jupytext Notebook".
+Then right-click on one of the chapter's `.md` files and select "Open With" > "Jupytext Notebook". 
+All cells can be edited / run directly in this interface.
 
 ## Funding
 


### PR DESCRIPTION
Closes https://github.com/HEFTIEProject/heftie-textbook/issues/44

Minor modifications to the developer docs in the `README`:
- updated jupyter book link to jupyter book 2
- added some minor extra info about the commands

Was there any more detail you wanted to include about `jupytext`? (as that was the main focus of the issue: https://github.com/HEFTIEProject/heftie-textbook/issues/44)