### PR TITLE
enable strict for jupyter book builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,6 +16,6 @@ build:
 
     build:
       html:
-        - cd book/ && jupyter book build --html --execute
+        - cd book/ && jupyter book build --html --execute --strict --ci
         - mkdir -p $READTHEDOCS_OUTPUT
         - mv ./book/_build/html $READTHEDOCS_OUTPUT


### PR DESCRIPTION
For https://github.com/HEFTIEProject/heftie-textbook/issues/45

Adds:
- `--strict` to stop on errors
- `--ci` to indicate this command is running during automated continuous integration